### PR TITLE
Added example-asyncio

### DIFF
--- a/micropython/uhttpd/examples/asyncio_uhttpd.py
+++ b/micropython/uhttpd/examples/asyncio_uhttpd.py
@@ -1,0 +1,24 @@
+import http_api_handler
+import uhttpd
+import uasyncio as asyncio
+
+class Handler:
+    def __init__(self):
+        pass
+    
+    def get(self, api_request):
+        print(api_request)
+        return {'foo': 'bar'}
+
+
+def simple_loop():
+    while True:
+        print("Yeehaw!")
+        await asyncio.sleep(1)
+
+api_handler = http_api_handler.Handler([(['test'], Handler())])
+
+loop = asyncio.get_event_loop()
+loop.create_task(simple_loop())
+server = uhttpd.Server([('/api', api_handler)])
+server.run()


### PR DESCRIPTION
Closes #6

Hi Fred,

Thanks for the response. I managed to get Picoweb and asyncio to play nicely. 
https://github.com/pfalcon/picoweb/issues/7#issuecomment-306634031

So applied the same (simple!) technique to uhttpd, 
```
import asyncio_uhttpd
INFO:None:uhttpd-master running...
Yeehaw!
Yeehaw!
Yeehaw!
Yeehaw!
Yeehaw!
{'http': {'path': '/api/test', 'prefix': '/api', 'verb': 'get', 'headers': {'user-agent': 'curl/7.47.0', 'host': '192.168.1.228', 'accept': '*/*'}, 'tcp': {'remote_addr': ('192.168.1.127', 37980)}, 'protocol': 'HTTP/1.1'}, 'prefix': ['test'], 'context': [], 'query_params': None, 'body': None}
Yeehaw!
Yeehaw!
Yeehaw!
Yeehaw!
{'http': {'path': '/api/test', 'prefix': '/api', 'verb': 'get', 'headers': {'user-agent': 'curl/7.47.0', 'host': '192.168.1.228', 'accept': '*/*'}, 'tcp': {'remote_addr': ('192.168.1.127', 37982)}, 'protocol': 'HTTP/1.1'}, 'prefix': ['test'], 'context': [], 'query_params': None, 'body': None}
Yeehaw!
Yeehaw!
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "asyncio_uhttpd.py", line 24, in <module>
  File "uhttpd.py", line 70, in run
  File "uhttpd.py", line 407, in run
  File "uasyncio/core.py", line 64, in run_forever
  File "uasyncio/__init__.py", line 58, in wait
KeyboardInterrupt: 
>>> 

```