### PR TITLE
Return HTML with http_api_handler

### DIFF
--- a/micropython/uhttpd/README.md
+++ b/micropython/uhttpd/README.md
@@ -301,7 +301,7 @@ The return value from these operations may one of the following:
 
 * A JSON structure (i.e., python Dictionary) that can be converted to a JSON string:  In this case, the body of the HTTP response is the converted JSON string, and the content type is set to `application/json`.
 * A raw byte array:  In this case, the raw byte array is returned in the body of the HTTP response, and the content type is set to `application/binary`.
-* A string: In this case, the string is returned as a body of HTTP response. Content-type is set to "text/html; charset=utf-8"
+* A string: In this case, the string is returned as a body of HTTP response. Content-type is set to `text/html; charset=utf-8`
 * `None`: In this case, the HTTP response contains no body.
 
 ### Exception Semantics

--- a/micropython/uhttpd/README.md
+++ b/micropython/uhttpd/README.md
@@ -300,7 +300,8 @@ The `tcp` entry contains the following elements:
 The return value from these operations may one of the following:
 
 * A JSON structure (i.e., python Dictionary) that can be converted to a JSON string:  In this case, the body of the HTTP response is the converted JSON string, and the content type is set to `application/json`.
-* A raw byte array:  In this case, the raw byte array is is returned in the body of the HTTP response, and the content type is set to `application/binary`.
+* A raw byte array:  In this case, the raw byte array is returned in the body of the HTTP response, and the content type is set to `application/binary`.
+* A string: In this case, the string is returned as a body of HTTP response. Content-type is set to "text/html; charset=utf-8"
 * `None`: In this case, the HTTP response contains no body.
 
 ### Exception Semantics

--- a/micropython/uhttpd/http_api_handler.py
+++ b/micropython/uhttpd/http_api_handler.py
@@ -78,6 +78,9 @@ class Handler:
             elif type(response) is bytes:
                 data = response
                 content_type = "application/binary"
+            elif type(response) is str:
+                data = response.encode("UTF-8")
+                content_type = "text/html; charset=utf-8"
             else:
                 raise Exception("Response from API Handler is neither dict nor bytearray nor None")
             body = lambda stream: stream.awrite(data)

--- a/micropython/uhttpd/test/README.md
+++ b/micropython/uhttpd/test/README.md
@@ -9,7 +9,7 @@ Upload `test_server.py` to your ESP8266 using `webrepl` or equivalent, and run t
     >>> import test_server
     >>> test_server.init()
     Initializing...
-    >>> test_server.start()
+    >>> test_server.run()
     Starting test server ...
     loaded sink console
     2000-01-01T15:45:02.005 [info] esp8266: uhttpd-master started.

--- a/micropython/uhttpd/test/test_client.py
+++ b/micropython/uhttpd/test/test_client.py
@@ -178,6 +178,10 @@ class HttpdTest(unittest.TestCase):
         self.verify_get('/api/test/not_found_excetion', expected_status=404, expected_content_type="text/html")
         self.verify_get('/api/test/forbidden_excetion', expected_status=403, expected_content_type="text/html")
 
+    def test_api_html(self):
+        self.verify_get('/api/test/html', expected_status=200, expected_content_type="text/html; charset=utf-8",
+            expected_body="<html><body><h1>HTML</h1></body></html>".encode("UTF-8"))
+
     def verify_get(
         self, context, body=None, additional_headers={},
         expected_status=None, expected_content_type=None, expected_body=None

--- a/micropython/uhttpd/test/test_server.py
+++ b/micropython/uhttpd/test/test_server.py
@@ -69,6 +69,8 @@ class TestAPIHandler:
                 return b''
             elif what_to_return == "something":
                 return b'something'
+            elif what_to_return == "html":
+                return "<html><body><h1>HTML</h1></body></html>"
             elif what_to_return == "bad_request_excetion":
                 raise uhttpd.BadRequestException("derp")
             elif what_to_return == "not_found_excetion":


### PR DESCRIPTION
REST is good, but generating HTML pages on-the-fly is also good and useful.
Returning a string from the get/post/put/delete methods sends an HTML content-type.